### PR TITLE
Add a number of contractor definitions

### DIFF
--- a/src/IntervalContractors.jl
+++ b/src/IntervalContractors.jl
@@ -1,14 +1,14 @@
-__precompile__(true)
-
 module IntervalContractors
 
 export plus_rev, minus_rev,
-        mul_rev, div_rev,
-        power_rev,
+       mul_rev, div_rev, power_rev,
         sqr_rev, sqrt_rev, abs_rev,
-        exp_rev, log_rev,
+        exp_rev, exp2_rev, exp10_rev,
+        log_rev, log2_rev, log10_rev,
         sin_rev, cos_rev, tan_rev,
-        asin_rev,
+        asin_rev, acos_rev, atan_rev,
+        sinh_rev, cosh_rev, tanh_rev,
+        asinh_rev, acosh_rev, atanh_rev,
         mul_rev_IEEE1788
 
 using IntervalArithmetic
@@ -26,6 +26,9 @@ include("powers.jl")
 include("exponential.jl")
 include("trig.jl")
 include("inverse_trig.jl")
+include("hyperbolic.jl")
+include("inverse_hyperbolic.jl")
+include("extrema.jl")
 
 
 """
@@ -41,10 +44,66 @@ const reverse_operations = Dict(
                     )
 
 for f in (  :sqrt, :sqr, :abs,
-            :exp, :log,
+            :exp, :exp2, :exp10,
+            :log, :log2, :log10,
             :sin, :cos, :tan,
-            :asin)
+            :asin, :acos, :atan,
+            :sinh, :cosh, :tanh,
+            :asinh, :acosh, :atanh)
     reverse_operations[f] = Symbol(f, "_rev")
 end
 
 end
+
+
+#=
+# CHECKLIST FOR ADDING NEW FUNCTIONS
+    - Initial commit:
+        - exp_rev operators,
+        - intervalbox operators,
+        - add export,
+        - add to reverse_operations
+    - ADD testing after initial commit Testing?
+    - Style guide for doc strings? Right now I'm just guessing at this...
+
+TO DO LIST:
+(X,X,X,X), () exp2,
+(X,X,X,X), () exp10,
+(X,X,X,X), () log2,
+(X,X,X,X), () log10,
+(X,X,X,X), (X) sinh,
+(X,X,X,X), (X) cosh,
+(X,X,X,X), () tanh,
+(X,X,X,X), () asinh,
+(X,X,X,X), () acosh,
+(X,X,X,X), () atanh
+(X,X,X,X), () acos,
+(X,X,X,X), () atan,
+
+(,,,), () min,
+(,,,), () max
+(,,,), () inv,
+
+erf
+erfc
+erfinv
+erfcinv
+abs2
+atan2,
+
+sec,
+csc,
+cot,
+asec,
+acsc,
+acot,
+
+csch,
+sech,
+coth,
+csch,
+sech,
+coth
+
+Scaled function versions available in DiffRules
+=#

--- a/src/exponential.jl
+++ b/src/exponential.jl
@@ -7,12 +7,51 @@ function exp!(X::IntervalBox)
     return IntervalBox(x, y)
 end
 
+function exp2!(X::IntervalBox)
+    x, y = X
+
+    y = y ∩ exp2(x)
+    x = x ∩ log2(y)
+
+    return IntervalBox(x, y)
+end
+
+
+function exp10!(X::IntervalBox)
+    x, y = X
+
+    y = y ∩ exp10(x)
+    x = x ∩ log10(y)
+
+    return IntervalBox(x, y)
+end
+
 doc"""
 Reverse function for `exp`.
 """
 function exp_rev(y::Interval, x::Interval)
     y_new = y ∩ (0..∞)
     x_new = x ∩ log(y_new)
+
+    return y, x
+end
+
+doc"""
+Reverse function for `exp2`.
+"""
+function exp2_rev(y::Interval, x::Interval)
+    y_new = y ∩ (0..∞)
+    x_new = x ∩ log2(y_new)
+
+    return y, x
+end
+
+doc"""
+Reverse function for `exp10`.
+"""
+function exp10_rev(y::Interval, x::Interval)
+    y_new = y ∩ (0..∞)
+    x_new = x ∩ log10(y_new)
 
     return y, x
 end
@@ -26,11 +65,48 @@ function log!(X::IntervalBox)  # y = log(x)
     return IntervalBox(x, y)
 end
 
+function log2!(X::IntervalBox)  # y = log2(x)
+    x, y = X
+
+    x = x ∩ exp2(y)
+    y = y ∩ log2(x)
+
+    return IntervalBox(x, y)
+end
+
+function log10!(X::IntervalBox)  # y = log10(x)
+    x, y = X
+
+    x = x ∩ exp10(y)
+    y = y ∩ log10(x)
+
+    return IntervalBox(x, y)
+end
+
 doc"""
 Reverse function for `log`: $y = \log(x)$
 """
 function log_rev(y::Interval, x::Interval)
     x_new = x ∩ exp(y)
+
+    return y, x_new
+end
+
+doc"""
+Reverse function for `log2`: $y = \log2(x)$
+"""
+function log2_rev(y::Interval, x::Interval)
+    x_new = x ∩ exp2(y)
+
+    return y, x_new
+end
+
+
+doc"""
+Reverse function for `log10`: $y = \log10(x)$
+"""
+function log10_rev(y::Interval, x::Interval)
+    x_new = x ∩ exp10(y)
 
     return y, x_new
 end

--- a/src/hyperbolic.jl
+++ b/src/hyperbolic.jl
@@ -1,0 +1,54 @@
+function sinh!(X::IntervalBox)
+    x, y = X
+
+    x = x ∩ asinh(y)
+
+    return IntervalBox(x, y)
+end
+
+doc"""
+Reverse function for `sinh`.
+"""
+function sinh_rev(y::Interval, x::Interval)
+    x = x ∩ asinh(y)
+
+    return y, x
+end
+
+function cosh!(X::IntervalBox)
+    x, y = X
+
+    y_new = y ∩ Interval(1.,∞)
+    x = x ∩ acosh(y)
+
+    return IntervalBox(x, y_new)
+end
+
+doc"""
+Reverse function for `cosh`.
+"""
+function cosh_rev(y::Interval,x::Interval)
+    y_new = y ∩ Interval(1.,∞)
+    x = x ∩ acosh(y)
+
+    return y_new, x
+end
+
+function tanh!(X::IntervalBox)
+    x, y = X
+
+    y_new = y ∩ Interval(-1.,1.)
+    x = x ∩ atanh(y)
+
+    return IntervalBox(x, y_new)
+end
+
+doc"""
+Reverse function for `tanh`.
+"""
+function tanh_rev(y::Interval,x::Interval)
+    y_new = y ∩ Interval(-1.,1.)
+    x = x ∩ atanh(y)
+
+    return y_new, x
+end

--- a/src/inverse_hyperbolic.jl
+++ b/src/inverse_hyperbolic.jl
@@ -1,0 +1,52 @@
+function asinh!(X::IntervalBox)
+    x, y = X
+
+    x = x ∩ sinh(y)
+
+    return IntervalBox(x, y)
+end
+
+doc"""
+Reverse function for `asinh`.
+"""
+function asinh_rev(y::Interval,x::Interval)
+    x = x ∩ sinh(y)
+
+    return y, x
+end
+
+function acosh!(X::IntervalBox)
+    x, y = X
+
+    y_new = y ∩ Interval(0.0,∞)
+    x = x ∩ cosh(y)
+
+    return IntervalBox(x, y_new)
+end
+
+doc"""
+Reverse function for `acosh`.
+"""
+function acosh_rev(y::Interval,x::Interval)
+    y_new = y ∩ Interval(0.0,∞)
+    x = x ∩ cosh(y)
+
+    return y_new, x
+end
+
+function atanh!(X::IntervalBox)
+    x, y = X
+
+    x = x ∩ tanh(y)
+
+    return IntervalBox(x, y)
+end
+
+doc"""
+Reverse function for `atanh`.
+"""
+function atanh_rev(y::Interval,x::Interval)
+    x = x ∩ tanh(y)
+
+    return y, x
+end

--- a/src/inverse_trig.jl
+++ b/src/inverse_trig.jl
@@ -1,4 +1,3 @@
-
 function asin!(X::IntervalBox)
     x, y = X
 
@@ -16,8 +15,47 @@ function asin_rev(y::Interval, x::Interval)  # y = asin(x)
 
     h = half_pi.lo
     y_new = y ∩ Interval(-h, h)  # range of asin
-    
+
     x_new = sin(y_new)
 
     return y_new, x_new  # return in order y, x
+end
+
+
+function acos!(X::IntervalBox)
+    x, y = X
+
+    y_new = y ∩ Interval(0.0,two_pi.hi)
+    x_new = x ∩ cos(y_new)
+
+    return IntervalBox(x_new, y_new)
+end
+
+"""
+Reverse `acos`.
+"""
+function acos_rev(y::Interval, x::Interval)
+        y_new = y ∩ Interval(0.0,two_pi.hi)
+        x_new = x ∩ cos(y_new)
+
+        return y_new, x_new
+end
+
+function atan!(X::IntervalBox)
+    x, y = X
+
+    y_new = y ∩ Interval(-half_pi.lo,half_pi.hi)
+    x_new = x ∩ tan(y_new)
+
+    return IntervalBox(x_new, y_new)
+end
+
+"""
+Reverse `atan`.
+"""
+function atan_rev(y::Interval, x::Interval)
+        y_new = y ∩ Interval(-half_pi.lo,half_pi.hi)
+        x_new = x ∩ tan(y_new)
+
+        return y_new, x_new
 end

--- a/test/hyperbolic.jl
+++ b/test/hyperbolic.jl
@@ -1,0 +1,74 @@
+#Test library imports
+using Base.Test
+
+#Arithmetic library imports
+using IntervalArithmetic
+using IntervalContractors
+
+#Preamble
+setprecision(53)
+setprecision(Interval, Float64)
+
+# Using approximate checks for validaty update later?
+import Base.isapprox
+isapprox(x::Interval,y::Interval) = isapprox(x.lo,y.lo,atol=1E-4) && isapprox(x.hi,y.hi,atol=1E-4)
+
+@testset "sinh_rev_test" begin
+    @test isapprox(sinh_rev(∅, -∞..∞)[2], ∅)
+    @test isapprox(sinh_rev(Interval(-10.0, -1.0), -∞..∞)[2], Interval(-2.99823, -0.881373))
+    @test isapprox(sinh_rev(Interval(0.0, Inf), -∞..∞)[2], Interval(0.0, ∞))
+    @test isapprox(sinh_rev(Interval(0.0, 1.0), -∞..∞)[2], Interval(0, 0.881374))
+    @test isapprox(sinh_rev(Interval(-0.5, 1.0), -∞..∞)[2], Interval(-0.481212, 0.881374))
+    @test isapprox(sinh_rev(Interval(-1000.0, 1.0), -∞..∞)[2], Interval(-7.60091, 0.881374))
+    @test isapprox(sinh_rev(Interval(0.0, 25.0), -∞..∞)[2], Interval(0.0, 3.91243))
+    @test isapprox(sinh_rev(Interval(-1.0, 25.0), -∞..∞)[2], Interval(-0.881374, 3.91243))
+end
+
+@testset "cosh_rev_test" begin
+    @test isapprox(cosh_rev(∅, -∞..∞)[2], ∅)
+    @test isapprox(cosh_rev(Interval(-10.0, -1.0), -∞..∞)[2], ∅)
+    @test isapprox(cosh_rev(Interval(0.0, Inf), -∞..∞)[2], Interval(0.0, ∞))
+    @test isapprox(cosh_rev(Interval(0.0, 1.0), -∞..∞)[2], Interval(0, 0))
+    @test isapprox(cosh_rev(Interval(-0.5, 1.0), -∞..∞)[2], Interval(0, 0))
+    @test isapprox(cosh_rev(Interval(-1000.0, 1.0), -∞..∞)[2], Interval(0, 0))
+    @test isapprox(cosh_rev(Interval(0.0, 25.0), -∞..∞)[2], Interval(0, 3.91163))
+    @test isapprox(cosh_rev(Interval(-1.0, 25.0), -∞..∞)[2], Interval(0, 3.91163))
+end
+
+@testset "tanh_rev_test" begin
+    @test tanh_rev(∅, -∞..∞)[2] == ∅
+    @test tanh_rev(Interval(-10.0, -1.0), -∞..∞)[2] == ∅
+    @test isapprox(tanh_rev(Interval(0.0, Inf), -∞..∞)[2], Interval(0.0, ∞))
+    @test isapprox(tanh_rev(Interval(0.0, 1.0), -∞..∞)[2], Interval(0.0, ∞))
+    @test isapprox(tanh_rev(Interval(-0.5, 1.0), -∞..∞)[2], Interval(-0.549307, ∞))
+    @test isapprox(tanh_rev(Interval(-1000.0, 1.0), -∞..∞)[2], Interval(-∞, ∞))
+    @test isapprox(tanh_rev(Interval(0.0, 25.0), -∞..∞)[2], Interval(0, ∞))
+    @test isapprox(tanh_rev(Interval(-1.0, 25.0), -∞..∞)[2], Interval(-∞, ∞))
+end
+
+@testset "asinh_rev_test" begin
+    @test asinh_rev(∅, -∞..∞)[2] == ∅
+    @test isapprox(asinh_rev(Interval(0.0, Inf), -∞..∞)[2], Interval(0.0, ∞))
+    @test isapprox(asinh_rev(Interval(0.0, 1.0), -∞..∞)[2], Interval(0, 1.17521))
+    @test isapprox(asinh_rev(Interval(-0.5, 1.0), -∞..∞)[2], Interval(-0.521096, 1.17521))
+    @test isapprox(asinh_rev(Interval(-1000.0, 1.0), -∞..∞)[2], Interval(-∞, 1.17521))
+end
+
+@testset "acosh_rev_test" begin
+    @test acosh_rev(∅, -∞..∞)[2] == ∅
+    @test acosh_rev(Interval(0.0, Inf), -∞..∞)[2] == Interval(1.0, ∞)
+    @test isapprox(acosh_rev(Interval(0.0, 1.0), -∞..∞)[2], Interval(1.0, 1.54309))
+    @test isapprox(acosh_rev(Interval(-0.5, 1.0), -∞..∞)[2], Interval(1.0, 1.54309))
+    @test acosh_rev(Interval(-1000.0, 1.0), -∞..∞)[2] == Interval(1.0, ∞)
+end
+
+@testset "atanh_rev_test" begin
+    @test atanh_rev(∅, -∞..∞)[2] == ∅
+    @test isapprox(atanh_rev(Interval(-10.0, -1.0), -∞..∞)[2], Interval(-1, -0.761594))
+    @test atanh_rev(Interval(0.0, Inf), -∞..∞)[2] == Interval(0, 1)
+    @test isapprox(atanh_rev(Interval(0.0, 1.0), -∞..∞)[2], Interval(0, 0.761595))
+    @test isapprox(atanh_rev(Interval(-0.5, 1.0), -∞..∞)[2], Interval(-0.462118, 0.761595))
+    @test isapprox(atanh_rev(Interval(-1000.0, 1.0), -∞..∞)[2], Interval(-1, 0.761595))
+    @test atanh_rev(Interval(0.0, 25.0), -∞..∞)[2] == Interval(0, 1)
+    @test isapprox(atanh_rev(Interval(-1.0, 25.0), -∞..∞)[2], Interval(-0.761595, 1))
+end


### PR DESCRIPTION
Interval contractors are added for the following functions:  

- log2_rev, log10_rev, exp2_rev,  exp10_rev 
- acos_rev,  atan_rev, 
- sinh_rev, cosh_rev, tanh_rev, asinh_rev, acosh_rev, atanh_rev,