### PR TITLE
Removed duplicate definition

### DIFF
--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -1,9 +1,4 @@
 
-import Base: ^
-
-^(x::Interval{Float64}, r::Rational) = x^(convert(Interval{Float64}, r))
-
-
 """
 Reverse plus
 """


### PR DESCRIPTION
Function ``^(x::Interval{Float64}, r::Rational) = x^(convert(Interval{Float64}, r))`` already defined in IntervalArithmetic.jl