### PR TITLE
Fails with version 0.16.3 of IntervalArithmetic #39

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,7 @@ version = "0.4.2"
 IntervalArithmetic = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"
 
 [compat]
-IntervalArithmetic = "≥ 0.16"
+IntervalArithmetic = "≥ 0.16.3"
 julia = "≥ 1.1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "IntervalContractors"
 uuid = "15111844-de3b-5229-b4ba-526f2f385dc9"
-version = "0.4.1"
+version = "0.4.2"
 
 [deps]
 IntervalArithmetic = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"

--- a/src/trig.jl
+++ b/src/trig.jl
@@ -60,7 +60,7 @@ function cos_main(X::IntervalBox)
 
     x, y = X
 
-    x_range = Interval(0, IntervalArithmetic.pi_interval(Float64).lo)
+    x_range = Interval(0, Interval{Float64}(π).lo)
     y_range = -1..1
 
     x = x ∩ x_range
@@ -125,7 +125,7 @@ function tan_main(X::IntervalBox)
 
 end
 
-tan!(X::IntervalBox) = periodise(tan_main, IntervalArithmetic.pi_interval(Float64))(X)
+tan!(X::IntervalBox) = periodise(tan_main, Interval{Float64}(π))(X)
 
 """
     tan_rev(y::Interval, x::Interval)

--- a/test/Non1788tests/exponential.jl
+++ b/test/Non1788tests/exponential.jl
@@ -39,8 +39,8 @@ end
     @test expm1_rev(∅, Interval(0.0, 1.0))[2] == ∅
     @test expm1_rev(Interval(-2.0, -1.0), entireinterval(Float64))[2] == ∅
     @test isapprox(expm1_rev(Interval(1.0, 1.0), entireinterval(Float64))[2],Interval(0.693147, 0.693148))
-    @test expm1_rev(entireinterval(Float64), entireinterval(Float64))[2] == Interval(0.0, ∞)
-    @test expm1_rev(Interval(-Inf, 0.0), entireinterval(Float64))[2] == ∅
+    @test expm1_rev(entireinterval(Float64), entireinterval(Float64))[2] == Interval(-∞, ∞)
+    @test expm1_rev(Interval(-Inf, -1.0), entireinterval(Float64))[2] == ∅
 end
 
 @testset "log2_rev_test" begin


### PR DESCRIPTION
- Removes pi_interval syntax
- Fixes a broken test for expm1 (error was in the test not the expm1 function).