### PR TITLE
fix precompilation issue

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "IntervalContractors"
 uuid = "15111844-de3b-5229-b4ba-526f2f385dc9"
-version = "0.4.6"
+version = "0.4.7"
 
 [deps]
 IntervalArithmetic = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -334,14 +334,3 @@ function mul_rev_to_pair(b::DecoratedInterval{T}, c::DecoratedInterval{T}) where
     x1, x2 = extended_div(interval(c), interval(b))
     return (DecoratedInterval(x1, trv), DecoratedInterval(x2, trv))
 end
-
-mul_rev_to_pair(b::Interval, c::Interval) = extended_div(c, b)
-
-function mul_rev_to_pair(b::DecoratedInterval{T}, c::DecoratedInterval{T}) where T
-    (isnai(b) || isnai(c)) && return (nai(T), nai(T))
-
-    0 ∉ b && return (c/b, DecoratedInterval(emptyinterval(T), trv))
-
-    x1, x2 = extended_div(interval(c), interval(b))
-    return (DecoratedInterval(x1, trv), DecoratedInterval(x2, trv))
-end


### PR DESCRIPTION
In the previous PR I had accidentally the same code copy-pasted twice... shame on me!! 🤦‍♂️ 🙊  This gave some precompilation issues as it was redefining the methods. Fixed now

```julia
julia> using IntervalContractors
[ Info: Precompiling IntervalContractors [15111844-de3b-5229-b4ba-526f2f385dc9]
WARNING: Method definition mul_rev_to_pair(IntervalArithmetic.Interval{T} where T<:Real, IntervalArithmetic.Interval{T} where T<:Real) in module IntervalContractors at /home/lferrant/.julia/dev/IntervalContractors/src/arithmetic.jl:327 overwritten at /home/lferrant/.julia/dev/IntervalContractors/src/arithmetic.jl:338.
  ** incremental compilation may be fatally broken for this module **

WARNING: Method definition mul_rev_to_pair(IntervalArithmetic.DecoratedInterval{T}, IntervalArithmetic.DecoratedInterval{T}) where {T} in module IntervalContractors at /home/lferrant/.julia/dev/IntervalContractors/src/arithmetic.jl:329 overwritten at /home/lferrant/.julia/dev/IntervalContractors/src/arithmetic.jl:340.
  ** incremental compilation may be fatally broken for this module **
```